### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
-    "query-string": "^8.1.0"
+    "query-string": "^8.1.0",
+    "express-rate-limit": "^8.2.1"
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
+import rateLimit from 'express-rate-limit';
 import axios from 'axios';
 import queryString from 'query-string';
 import jwt from 'jsonwebtoken';
@@ -38,7 +39,15 @@ const getTokenParams = (code) =>
 
   const app = express();
 
-  // Resolve CORS
+// Rate limiter for /user/posts route
+const userPostsLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+});
+
+// Resolve CORS
 app.use(cors({
   origin: [
     config.clientUrl,
@@ -129,7 +138,7 @@ app.post("/auth/logout", (_, res) => {
   res.clearCookie("token").json({ message: "Logged out" });
 });
 
-app.get("/user/posts", auth, async (_, res) => {
+app.get("/user/posts", userPostsLimiter, auth, async (_, res) => {
   try {
     const { data } = await axios.get(config.postUrl);
     res.json({ posts: data?.slice(0, 5) });


### PR DESCRIPTION
Potential fix for [https://github.com/sukanyapedamkar/React-OAuth2/security/code-scanning/2](https://github.com/sukanyapedamkar/React-OAuth2/security/code-scanning/2)

To fix the problem, we should add a rate-limiting middleware to the `/user/posts` route (or more broadly, to any or all authenticated/data-fetching routes as appropriate). This is best done using a well-maintained package such as `express-rate-limit`. The package should be imported at the top, a rate limiter instance created (with sensible defaults like 100 requests per 15 minutes per IP), and the middleware applied to the `/user/posts` route. 

**Implementation steps in this file:**
- Add import: `import rateLimit from 'express-rate-limit';`
- Create a limiter instance (e.g., `const userPostsLimiter = rateLimit({ ... });`) after Express is initialized.
- Apply `userPostsLimiter` to the `/user/posts` route as an additional middleware, just before `auth`.
- No changes to existing business logic aside from adding this middleware chain.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
